### PR TITLE
タイムゾーンを日本に設定

### DIFF
--- a/volumes/jewelstone/run.sh
+++ b/volumes/jewelstone/run.sh
@@ -4,6 +4,10 @@ if ! which curl >/dev/null 2>/dev/null; then
     apk --no-cache add curl
 fi
 
+apk --no-cache add tzdata
+cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
+apk --no-cache del tzdata
+
 echo '0 7 * * * /opt/bin/notify.sh' >/var/spool/cron/crontabs/root
 echo '0 19 * * * /opt/bin/notify.sh' >>/var/spool/cron/crontabs/root
 


### PR DESCRIPTION
`alpine:3.6` のタイムゾーンは UTC のため、日本で想定している時間より 9 時間遅れてしまいます。